### PR TITLE
Add rate limiting and custom 404 middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,35 @@ UPLOAD_MAX_FILE_SIZE=10485760  # 10MB in bytes
 UPLOAD_PATH="static/uploads"
 
 #-------------------------------
+# Rate Limiting
+#-------------------------------
+# Enable/disable rate limiting globally
+RATE_LIMIT_ENABLED=true
+# Backing store: "memory" (single instance) or "redis" (multi-instance)
+RATE_LIMIT_STORE=memory
+# Response format for 429 errors: "json" or "html"
+RATE_LIMIT_RESPONSE_FORMAT=json
+# Log denied requests to the rate_limit_logs database table
+RATE_LIMIT_LOG_TABLE=false
+# Trusted reverse proxies (comma-separated IPs or CIDRs)
+RATE_LIMIT_TRUSTED_PROXIES=
+# Default policy values
+RATE_LIMIT_DEFAULT_LIMIT=300
+RATE_LIMIT_DEFAULT_WINDOW=60
+RATE_LIMIT_DEFAULT_BURST=60
+
+#-------------------------------
+# Rate Limiting Redis Config
+#-------------------------------
+# Falls back to SESSION_REDIS_* values if not set
+RATE_LIMIT_REDIS_HOST=localhost
+RATE_LIMIT_REDIS_PORT=6379
+RATE_LIMIT_REDIS_PASSWORD=
+RATE_LIMIT_REDIS_DB=0
+# Key prefix for all rate-limit keys in Redis
+RATE_LIMIT_REDIS_PREFIX=gohst:rl:
+
+#-------------------------------
 # Frontend Development (Vite)
 #-------------------------------
 # Path to Vite's manifest file

--- a/database/migrations/2025_02_24_135000_create_rate_limit_logs.sql
+++ b/database/migrations/2025_02_24_135000_create_rate_limit_logs.sql
@@ -1,0 +1,17 @@
+CREATE TABLE rate_limit_logs (
+    id              BIGSERIAL PRIMARY KEY,
+    method          VARCHAR(10) NOT NULL,
+    path            VARCHAR(2048) NOT NULL,
+    key_type        VARCHAR(20) NOT NULL,
+    key_hash        VARCHAR(100) NOT NULL,
+    scope           VARCHAR(50) NOT NULL DEFAULT 'default',
+    retry_after     INTEGER NOT NULL DEFAULT 0,
+    client_ip       VARCHAR(45) NOT NULL,
+    denied_at       TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    created_at      TIMESTAMPTZ DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+-- Index for querying recent denials by scope / key
+CREATE INDEX idx_rate_limit_logs_scope_denied ON rate_limit_logs (scope, denied_at DESC);
+CREATE INDEX idx_rate_limit_logs_client_ip    ON rate_limit_logs (client_ip, denied_at DESC);
+CREATE INDEX idx_rate_limit_logs_key_hash     ON rate_limit_logs (key_hash, denied_at DESC);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,5 +12,6 @@ func InitConfig(envName ...string) {
 	initEnv(env)
 	initSession()
 	initVite()
+	initRateLimit()
 
 }

--- a/internal/config/ratelimit.go
+++ b/internal/config/ratelimit.go
@@ -1,0 +1,97 @@
+package config
+
+// RateLimitConfig holds all rate-limiter related configuration
+type RateLimitConfig struct {
+	// Enabled toggles the rate limiter on/off globally
+	Enabled bool
+
+	// Store is the backing store type: "memory" or "redis"
+	Store string
+
+	// RedisPrefix is the key prefix for all rate-limit keys in Redis
+	RedisPrefix string
+
+	// Redis holds the Redis connection config (shared with session if desired)
+	Redis *RedisConfig
+
+	// TrustedProxies is a list of CIDR ranges or IPs that are trusted reverse proxies.
+	// X-Forwarded-For / X-Real-IP headers are only honoured from these peers.
+	TrustedProxies []string
+
+	// DefaultResponseFormat is the content type for 429 responses: "json" or "html"
+	DefaultResponseFormat string
+
+	// LogTableEnabled controls whether denied requests are logged to the database
+	LogTableEnabled bool
+
+	// --- Default policy values (used when no per-route policy is set) ---
+	DefaultLimit  int
+	DefaultWindow int // seconds
+	DefaultBurst  int
+}
+
+var RateLimit *RateLimitConfig
+
+func initRateLimit() {
+	proxyStr := GetEnv("RATE_LIMIT_TRUSTED_PROXIES", "").(string)
+	var proxies []string
+	if proxyStr != "" {
+		for _, p := range splitCSV(proxyStr) {
+			proxies = append(proxies, p)
+		}
+	}
+
+	RateLimit = &RateLimitConfig{
+		Enabled:               GetEnv("RATE_LIMIT_ENABLED", true).(bool),
+		Store:                 GetEnv("RATE_LIMIT_STORE", "memory").(string),
+		RedisPrefix:           GetEnv("RATE_LIMIT_REDIS_PREFIX", "gohst:rl:").(string),
+		DefaultResponseFormat: GetEnv("RATE_LIMIT_RESPONSE_FORMAT", "json").(string),
+		LogTableEnabled:       GetEnv("RATE_LIMIT_LOG_TABLE", false).(bool),
+		DefaultLimit:          GetEnv("RATE_LIMIT_DEFAULT_LIMIT", 300).(int),
+		DefaultWindow:         GetEnv("RATE_LIMIT_DEFAULT_WINDOW", 60).(int),
+		DefaultBurst:          GetEnv("RATE_LIMIT_DEFAULT_BURST", 60).(int),
+		TrustedProxies:        proxies,
+		Redis: &RedisConfig{
+			DB:       GetEnv("RATE_LIMIT_REDIS_DB", 0).(int),
+			Host:     GetEnv("RATE_LIMIT_REDIS_HOST", GetEnv("SESSION_REDIS_HOST", "localhost").(string)).(string),
+			Password: GetEnv("RATE_LIMIT_REDIS_PASSWORD", GetEnv("SESSION_REDIS_PASSWORD", "").(string)).(string),
+			Port:     GetEnv("RATE_LIMIT_REDIS_PORT", GetEnv("SESSION_REDIS_PORT", 6379).(int)).(int),
+		},
+	}
+}
+
+// splitCSV is a small helper to split a comma-separated string
+func splitCSV(s string) []string {
+	var result []string
+	for _, part := range splitBy(s, ',') {
+		trimmed := trimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func splitBy(s string, sep byte) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+func trimSpace(s string) string {
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}

--- a/internal/middleware/not_found.go
+++ b/internal/middleware/not_found.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"gohst/internal/render"
+	"net/http"
+)
+
+type responseWriter404 struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *responseWriter404) WriteHeader(status int) {
+	w.status = status
+	if status != http.StatusNotFound {
+		w.ResponseWriter.WriteHeader(status)
+	}
+}
+
+func (w *responseWriter404) Write(b []byte) (int, error) {
+	if w.status == http.StatusNotFound {
+		return len(b), nil // Suppress the default "404 page not found" text
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// NotFound returns a middleware that intercepts 404 responses and renders a custom 404 page.
+func NotFound(templateName string) func(http.Handler) http.Handler {
+	// Initialize a view instance for rendering the 404 page.
+	// We do this once here so we don't re-parse templates on every 404.
+	view := render.NewView()
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rw := &responseWriter404{ResponseWriter: w}
+			next.ServeHTTP(rw, r)
+
+			if rw.status == http.StatusNotFound {
+				// It was a 404! Render our custom page
+				// We must explicitly set the status code here because we suppressed it earlier
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusNotFound)
+				view.Render(w, r, templateName, nil)
+			}
+		})
+	}
+}

--- a/internal/ratelimit/README.md
+++ b/internal/ratelimit/README.md
@@ -1,0 +1,233 @@
+# Rate Limiter
+
+A reusable, middleware-based rate limiter for the Gohst framework. It uses a **token bucket** algorithm with support for burst capacity, composite keys, and both in-memory and Redis-backed stores.
+
+## Quick Start
+
+### 1. Environment Variables (optional — all have defaults)
+
+Add any of these to your `.env` file to override defaults:
+
+```bash
+# Global on/off switch (default: true)
+RATE_LIMIT_ENABLED=true
+
+# Backing store: "memory" (single instance) or "redis" (multi-instance)
+RATE_LIMIT_STORE=memory
+
+# Redis config (falls back to SESSION_REDIS_* values if not set)
+RATE_LIMIT_REDIS_HOST=localhost
+RATE_LIMIT_REDIS_PORT=6379
+RATE_LIMIT_REDIS_PASSWORD=
+RATE_LIMIT_REDIS_DB=0
+RATE_LIMIT_REDIS_PREFIX=gohst:rl:
+
+# Response format for 429 errors: "json" or "html"
+RATE_LIMIT_RESPONSE_FORMAT=json
+
+# Log denied requests to the database (requires migration)
+RATE_LIMIT_LOG_TABLE=false
+
+# Trusted reverse proxies (comma-separated IPs or CIDRs)
+RATE_LIMIT_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
+
+# Default policy values (used when no per-route policy is set)
+RATE_LIMIT_DEFAULT_LIMIT=300
+RATE_LIMIT_DEFAULT_WINDOW=60
+RATE_LIMIT_DEFAULT_BURST=60
+```
+
+### 2. Using in Routes (with `middleware.Chain`)
+
+The rate limiter produces a standard `func(http.Handler) http.Handler` middleware, so it drops directly into your existing `middleware.Chain` calls.
+
+```go
+package routes
+
+import (
+    "net/http"
+
+    "gohst/app/controllers"
+    "gohst/internal/middleware"
+    "gohst/internal/ratelimit"
+    "gohst/internal/session"
+)
+
+type AppRouter struct {
+    rlStore ratelimit.Store // shared store across all limiters
+}
+
+func NewAppRouter() *AppRouter {
+    return &AppRouter{
+        rlStore: ratelimit.NewStore(), // reads RATE_LIMIT_STORE env
+    }
+}
+
+// Public routes — generous limit (300/min, burst 60)
+func (r *AppRouter) setupPublicRoutes() http.Handler {
+    mux := http.NewServeMux()
+    pages := controllers.NewPagesController()
+
+    mux.HandleFunc("GET /{$}", pages.Index)
+    mux.HandleFunc("GET /", pages.NotFound)
+    mux.HandleFunc("GET /post/{id}", pages.Post)
+
+    publicLimiter := ratelimit.NewPublicBrowseLimiter(r.rlStore)
+
+    return middleware.Chain(
+        mux,
+        publicLimiter.Middleware,       // <-- rate limiter
+        session.SM.SessionMiddleware,
+        middleware.CSRF,
+        middleware.Logger,
+    )
+}
+
+// Auth routes — tight limit (10/min, keyed by IP + email)
+func (r *AppRouter) setupAuthRoutes() http.Handler {
+    mux := http.NewServeMux()
+    auth := controllers.NewAuthController()
+
+    mux.HandleFunc("GET /login", auth.Login)
+    mux.HandleFunc("POST /login", auth.HandleLogin)
+    mux.HandleFunc("GET /register", auth.Register)
+    mux.HandleFunc("POST /register", auth.HandleRegister)
+
+    authLimiter := ratelimit.NewAuthSensitiveLimiter(r.rlStore, "email")
+
+    guestRoutes := middleware.Chain(
+        mux,
+        authLimiter.Middleware,          // <-- rate limiter
+        session.SM.SessionMiddleware,
+        middleware.CSRF,
+        middleware.Logger,
+        middleware.Guest,
+    )
+
+    // ... rest of auth setup
+    return guestRoutes
+}
+```
+
+### 3. Custom Policies
+
+You can create your own policy for any route group:
+
+```go
+import "time"
+
+limiter := ratelimit.NewLimiter(
+    store,
+    ratelimit.Policy{
+        Limit:   50,
+        Window:  30 * time.Second,
+        Burst:   10,
+        Scope:   "api_search",
+        Enabled: true,
+        Cost:    1,   // or Cost: 5 for expensive endpoints
+    },
+    ratelimit.KeyByTokenElseUserElseIP(),
+)
+
+handler := middleware.Chain(mux, limiter.Middleware, ...)
+```
+
+### 4. Cost-Based Limiting
+
+Charge expensive endpoints more tokens per request:
+
+```go
+exportPolicy := ratelimit.Policy{
+    Limit:   10,
+    Window:  60 * time.Second,
+    Burst:   0,
+    Scope:   "exports",
+    Enabled: true,
+    Cost:    5, // each request costs 5 tokens
+}
+```
+
+## Preset Policies
+
+| Name                    | Limit   | Window | Burst | Key Strategy       | Use For                       |
+| ----------------------- | ------- | ------ | ----- | ------------------ | ----------------------------- |
+| `PublicBrowsePolicy()`  | 300/min | 60s    | 60    | user or IP         | Public pages                  |
+| `APIDefaultPolicy()`    | 120/min | 60s    | 30    | token, user, or IP | API endpoints                 |
+| `AuthSensitivePolicy()` | 10/min  | 60s    | 0     | IP + identifier    | Login, password reset         |
+| `ExportsPolicy()`       | 10/min  | 60s    | 0     | token or user      | Heavy exports + concurrency=1 |
+
+## Key Strategies
+
+Key functions determine **who** is being rate-limited:
+
+| Function                        | Key Format                                  | Best For                             |
+| ------------------------------- | ------------------------------------------- | ------------------------------------ |
+| `KeyByIP()`                     | `ip:<addr>`                                 | Fully anonymous routes               |
+| `KeyByUserElseIP()`             | `user:<id>` or `ip:<addr>`                  | Pages where users may be logged in   |
+| `KeyByTokenElseUserElseIP()`    | `token:<hash>`, `user:<id>`, or `ip:<addr>` | API routes                           |
+| `KeyByIPAndIdentifier("email")` | `ipident:<ip>:<hash>`                       | Login/reset (brute-force protection) |
+| `KeyByIPAndRoute()`             | `iproute:<ip>:<path>`                       | Limit specific expensive endpoints   |
+| `KeyByIPAndUA()`                | `ipua:<ip>:<hash>`                          | Fingerprint-style throttling         |
+
+## Allowlist / Bypass
+
+Skip rate limiting for health checks, internal services, or local dev:
+
+```go
+limiter := ratelimit.NewLimiter(store, policy, keyFunc,
+    ratelimit.WithAllowlist(
+        ratelimit.BypassPaths{Prefixes: []string{"/healthz", "/readyz"}},
+        ratelimit.BypassLocalDev{},
+        ratelimit.BypassIPs{Allowed: []string{"10.0.0.0/8"}},
+        ratelimit.BypassHeader{Header: "X-Internal-Token", Value: "secret"},
+    ),
+)
+```
+
+## Concurrency Limiting
+
+For heavy endpoints (exports, reports), cap **in-flight** requests per key in addition to the rate limit:
+
+```go
+concStore := ratelimit.NewMemoryConcurrencyStore()
+// or for multi-instance: ratelimit.NewRedisConcurrencyStore(redisClient, prefix, ttl)
+
+exportLimiter := ratelimit.NewExportsLimiter(store, concStore)
+```
+
+## Database Logging
+
+When `RATE_LIMIT_LOG_TABLE=true`, denied requests are logged to a `rate_limit_logs` table. Run the migration:
+
+```
+database/migrations/2025_02_24_135000_create_rate_limit_logs.sql
+```
+
+## Response Behavior
+
+When a request is denied the middleware returns:
+
+- **HTTP 429** Too Many Requests
+- **Headers**: `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+- **Body**: JSON (for API/Accept: application/json) or HTML (configurable via `RATE_LIMIT_RESPONSE_FORMAT`)
+
+## Architecture
+
+```
+internal/ratelimit/
+├── policy.go          # Policy struct + preset policies
+├── bucket.go          # Token bucket algorithm + Store/ConcurrencyStore interfaces
+├── store_memory.go    # In-memory store (dev / single-instance)
+├── store_redis.go     # Redis store with atomic Lua scripts (production)
+├── clientip.go        # Trusted-proxy-aware IP resolution
+├── keys.go            # Key computation functions
+├── middleware.go       # HTTP middleware + 429 response handling
+├── allowlist.go       # Bypass rules
+├── log.go             # Database + no-op log stores
+├── ratelimit.go       # Factory helpers + convenience constructors
+├── bucket_test.go     # Token bucket unit tests
+├── store_memory_test.go
+├── clientip_test.go
+├── keys_test.go
+└── middleware_test.go
+```

--- a/internal/ratelimit/allowlist.go
+++ b/internal/ratelimit/allowlist.go
@@ -1,0 +1,61 @@
+package ratelimit
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ──────────────────────────────────────────────
+// Allowlist / bypass rules
+// ──────────────────────────────────────────────
+
+// AllowRule determines whether a request should bypass rate limiting.
+type AllowRule interface {
+	Matches(r *http.Request) bool
+}
+
+// BypassLocalDev bypasses all requests from loopback addresses (127.0.0.1, ::1).
+type BypassLocalDev struct{}
+
+func (BypassLocalDev) Matches(r *http.Request) bool {
+	ip := ClientIP(r)
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.IsLoopback()
+}
+
+// BypassPaths bypasses requests whose path has a given prefix (e.g. /healthz).
+type BypassPaths struct {
+	Prefixes []string
+}
+
+func (b BypassPaths) Matches(r *http.Request) bool {
+	for _, p := range b.Prefixes {
+		if strings.HasPrefix(r.URL.Path, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// BypassIPs bypasses requests from specific IPs or CIDRs.
+type BypassIPs struct {
+	Allowed []string
+}
+
+func (b BypassIPs) Matches(r *http.Request) bool {
+	ip := ClientIP(r)
+	return isTrusted(ip, b.Allowed)
+}
+
+// BypassHeader bypasses requests that carry a specific header value,
+// useful for service-to-service communication with an internal token.
+// IMPORTANT: the value should be hashed before comparison in production.
+type BypassHeader struct {
+	Header string
+	Value  string
+}
+
+func (b BypassHeader) Matches(r *http.Request) bool {
+	return r.Header.Get(b.Header) == b.Value
+}

--- a/internal/ratelimit/bucket.go
+++ b/internal/ratelimit/bucket.go
@@ -1,0 +1,158 @@
+package ratelimit
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// ──────────────────────────────────────────────
+// Token bucket
+// ──────────────────────────────────────────────
+
+// Bucket tracks the token-bucket state for a single key.
+type Bucket struct {
+	Tokens    float64   // current number of available tokens
+	MaxTokens float64   // max capacity (limit + burst)
+	RefillRate float64  // tokens added per second
+	LastRefill time.Time // last time tokens were refilled
+}
+
+// NewBucket creates a bucket from a policy.
+func NewBucket(p Policy) *Bucket {
+	max := float64(p.Limit + p.Burst)
+	return &Bucket{
+		Tokens:     max, // starts full
+		MaxTokens:  max,
+		RefillRate: float64(p.Limit) / p.Window.Seconds(),
+		LastRefill: time.Now(),
+	}
+}
+
+// refill adds tokens based on elapsed time (idempotent).
+func (b *Bucket) refill(now time.Time) {
+	elapsed := now.Sub(b.LastRefill).Seconds()
+	if elapsed <= 0 {
+		return
+	}
+	b.Tokens = math.Min(b.MaxTokens, b.Tokens+elapsed*b.RefillRate)
+	b.LastRefill = now
+}
+
+// Allow tries to consume `cost` tokens. Returns remaining tokens and whether
+// the request is allowed.
+func (b *Bucket) Allow(cost int, now time.Time) (remaining int, allowed bool) {
+	b.refill(now)
+	c := float64(cost)
+	if b.Tokens >= c {
+		b.Tokens -= c
+		return int(b.Tokens), true
+	}
+	return 0, false
+}
+
+// RetryAfter returns seconds until `cost` tokens will be available.
+func (b *Bucket) RetryAfter(cost int) float64 {
+	deficit := float64(cost) - b.Tokens
+	if deficit <= 0 {
+		return 0
+	}
+	if b.RefillRate <= 0 {
+		return 0
+	}
+	return math.Ceil(deficit / b.RefillRate)
+}
+
+// ResetUnix returns the unix timestamp when the bucket will be fully refilled.
+func (b *Bucket) ResetUnix() int64 {
+	deficit := b.MaxTokens - b.Tokens
+	if deficit <= 0 {
+		return time.Now().Unix()
+	}
+	seconds := deficit / b.RefillRate
+	return time.Now().Add(time.Duration(seconds * float64(time.Second))).Unix()
+}
+
+// ──────────────────────────────────────────────
+// Result returned from Store.Allow
+// ──────────────────────────────────────────────
+
+// Result contains the outcome of a rate-limit check.
+type Result struct {
+	Allowed   bool
+	Limit     int
+	Remaining int
+	RetryAfter int   // seconds (0 when allowed)
+	ResetAt   int64  // unix timestamp
+}
+
+// ──────────────────────────────────────────────
+// Store interface
+// ──────────────────────────────────────────────
+
+// Store is the persistence backend for rate-limit buckets.
+type Store interface {
+	// Allow checks the rate limit for a key given a policy and cost.
+	Allow(key string, policy Policy, cost int) Result
+
+	// Reset removes a key from the store (e.g. after successful auth).
+	Reset(key string) error
+
+	// Close gracefully shuts down the store.
+	Close() error
+}
+
+// ──────────────────────────────────────────────
+// Concurrency Store interface (optional layer)
+// ──────────────────────────────────────────────
+
+// ConcurrencyStore manages per-key in-flight request counts.
+type ConcurrencyStore interface {
+	// Acquire increments the in-flight counter for key.
+	// Returns false if concurrency limit is reached.
+	Acquire(key string, limit int) (bool, error)
+
+	// Release decrements the in-flight counter for key.
+	Release(key string) error
+}
+
+// ──────────────────────────────────────────────
+// In-memory concurrency limiter
+// ──────────────────────────────────────────────
+
+// MemoryConcurrencyStore is a simple in-process concurrency limiter.
+type MemoryConcurrencyStore struct {
+	mu       sync.Mutex
+	inflight map[string]int
+}
+
+// NewMemoryConcurrencyStore creates a new in-memory concurrency store.
+func NewMemoryConcurrencyStore() *MemoryConcurrencyStore {
+	return &MemoryConcurrencyStore{
+		inflight: make(map[string]int),
+	}
+}
+
+// Acquire increments the in-flight counter. Returns false if limit reached.
+func (m *MemoryConcurrencyStore) Acquire(key string, limit int) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.inflight[key] >= limit {
+		return false, nil
+	}
+	m.inflight[key]++
+	return true, nil
+}
+
+// Release decrements the in-flight counter.
+func (m *MemoryConcurrencyStore) Release(key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.inflight[key] > 0 {
+		m.inflight[key]--
+	}
+	if m.inflight[key] == 0 {
+		delete(m.inflight, key)
+	}
+	return nil
+}

--- a/internal/ratelimit/bucket_test.go
+++ b/internal/ratelimit/bucket_test.go
@@ -1,0 +1,114 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBucket_AllowUpToLimit(t *testing.T) {
+	p := Policy{Limit: 5, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1}
+	b := NewBucket(p)
+	now := time.Now()
+
+	for i := 0; i < 5; i++ {
+		_, allowed := b.Allow(1, now)
+		if !allowed {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+}
+
+func TestBucket_DenyAfterLimit(t *testing.T) {
+	p := Policy{Limit: 3, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1}
+	b := NewBucket(p)
+	now := time.Now()
+
+	for i := 0; i < 3; i++ {
+		b.Allow(1, now)
+	}
+
+	_, allowed := b.Allow(1, now)
+	if allowed {
+		t.Fatal("request after limit should be denied")
+	}
+}
+
+func TestBucket_BurstAllowsExtra(t *testing.T) {
+	p := Policy{Limit: 5, Window: time.Minute, Burst: 3, Enabled: true, Cost: 1}
+	b := NewBucket(p)
+	now := time.Now()
+
+	// Should allow 5 + 3 = 8 requests
+	allowed := true
+	for i := 0; i < 8; i++ {
+		_, allowed = b.Allow(1, now)
+		if !allowed {
+			t.Fatalf("request %d should be allowed (burst capacity)", i+1)
+		}
+	}
+
+	_, allowed = b.Allow(1, now)
+	if allowed {
+		t.Fatal("request 9 should be denied (burst exhausted)")
+	}
+}
+
+func TestBucket_RefillAfterTime(t *testing.T) {
+	p := Policy{Limit: 10, Window: time.Second, Burst: 0, Enabled: true, Cost: 1}
+	b := NewBucket(p)
+
+	now := time.Now()
+	for i := 0; i < 10; i++ {
+		b.Allow(1, now)
+	}
+
+	_, allowed := b.Allow(1, now)
+	if allowed {
+		t.Fatal("should be denied when exhausted")
+	}
+
+	later := now.Add(time.Second)
+	_, allowed = b.Allow(1, later)
+	if !allowed {
+		t.Fatal("should be allowed after full refill")
+	}
+}
+
+func TestBucket_CostBasedLimiting(t *testing.T) {
+	p := Policy{Limit: 10, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1}
+	b := NewBucket(p)
+	now := time.Now()
+
+	_, allowed := b.Allow(5, now)
+	if !allowed {
+		t.Fatal("cost-5 request should be allowed")
+	}
+
+	_, allowed = b.Allow(5, now)
+	if !allowed {
+		t.Fatal("second cost-5 request should be allowed")
+	}
+
+	_, allowed = b.Allow(1, now)
+	if allowed {
+		t.Fatal("should be denied, all tokens consumed")
+	}
+}
+
+func TestBucket_RetryAfter(t *testing.T) {
+	p := Policy{Limit: 10, Window: 10 * time.Second, Burst: 0, Enabled: true, Cost: 1}
+	b := NewBucket(p)
+	now := time.Now()
+
+	for i := 0; i < 10; i++ {
+		b.Allow(1, now)
+	}
+
+	retry := b.RetryAfter(1)
+	if retry <= 0 {
+		t.Fatal("retryAfter should be positive when tokens exhausted")
+	}
+	if retry > 2 {
+		t.Fatalf("retryAfter should be about 1 second, got %.2f", retry)
+	}
+}

--- a/internal/ratelimit/clientip.go
+++ b/internal/ratelimit/clientip.go
@@ -1,0 +1,125 @@
+package ratelimit
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"gohst/internal/config"
+)
+
+// ──────────────────────────────────────────────
+// Client IP resolution
+// ──────────────────────────────────────────────
+
+// ClientIP extracts the real client IP from the request, respecting trusted
+// proxies from config.RateLimit.TrustedProxies. The rules:
+//
+//  1. If the immediate peer (RemoteAddr) is NOT in TrustedProxies, return it.
+//  2. If the peer IS trusted, inspect X-Real-IP first, then X-Forwarded-For
+//     (rightmost untrusted entry).
+//  3. Strip port, normalise IPv6.
+func ClientIP(r *http.Request) string {
+	peerIP := extractIP(r.RemoteAddr)
+
+	// Guard: config may not be initialised (e.g. in tests).
+	var trusted []string
+	if config.RateLimit != nil {
+		trusted = config.RateLimit.TrustedProxies
+	}
+
+	// If no trusted proxies configured, or peer is not trusted, return peer IP.
+	if len(trusted) == 0 || !isTrusted(peerIP, trusted) {
+		return normalizeIP(peerIP)
+	}
+
+	// Try X-Real-IP first (single value set by Nginx, etc.)
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		return normalizeIP(strings.TrimSpace(realIP))
+	}
+
+	// Walk X-Forwarded-For from right to left; return the first untrusted IP.
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff != "" {
+		parts := strings.Split(xff, ",")
+		for i := len(parts) - 1; i >= 0; i-- {
+			ip := strings.TrimSpace(parts[i])
+			if ip == "" {
+				continue
+			}
+			if !isTrusted(ip, trusted) {
+				return normalizeIP(ip)
+			}
+		}
+		// All entries are trusted? Fall back to leftmost.
+		if first := strings.TrimSpace(parts[0]); first != "" {
+			return normalizeIP(first)
+		}
+	}
+
+	return normalizeIP(peerIP)
+}
+
+// extractIP strips the port from host:port strings.
+func extractIP(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr // already bare IP
+	}
+	return host
+}
+
+// normalizeIP normalises an IP string: trims whitespace, parses + re-serialises
+// so that IPv4-mapped-IPv6 and other variants are standardised.
+func normalizeIP(raw string) string {
+	raw = strings.TrimSpace(raw)
+	ip := net.ParseIP(raw)
+	if ip == nil {
+		return raw
+	}
+	return ip.String()
+}
+
+// isTrusted returns true if `ip` matches any entry in the trusted list.
+// Entries can be plain IPs ("10.0.0.1") or CIDRs ("10.0.0.0/8").
+func isTrusted(ip string, trusted []string) bool {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false
+	}
+	for _, entry := range trusted {
+		// CIDR check
+		if strings.Contains(entry, "/") {
+			_, cidr, err := net.ParseCIDR(entry)
+			if err != nil {
+				continue
+			}
+			if cidr.Contains(parsedIP) {
+				return true
+			}
+		} else {
+			// Plain IP comparison
+			if net.ParseIP(entry) != nil && net.ParseIP(entry).Equal(parsedIP) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CoarsenIPv6 maps an IPv6 address to its /64 prefix for fairness (optional).
+// IPv4 addresses are returned unchanged.
+func CoarsenIPv6(ip string) string {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return ip
+	}
+	// IPv4 – no coarsening
+	if parsed.To4() != nil {
+		return ip
+	}
+	// Zero-out the last 8 bytes to get a /64. 
+	mask := net.CIDRMask(64, 128)
+	masked := parsed.Mask(mask)
+	return masked.String() + "/64"
+}

--- a/internal/ratelimit/clientip.go
+++ b/internal/ratelimit/clientip.go
@@ -118,7 +118,7 @@ func CoarsenIPv6(ip string) string {
 	if parsed.To4() != nil {
 		return ip
 	}
-	// Zero-out the last 8 bytes to get a /64. 
+	// Zero-out the last 8 bytes to get a /64.
 	mask := net.CIDRMask(64, 128)
 	masked := parsed.Mask(mask)
 	return masked.String() + "/64"

--- a/internal/ratelimit/clientip_test.go
+++ b/internal/ratelimit/clientip_test.go
@@ -1,0 +1,81 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIP_RemoteAddrDirect(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "192.168.1.100:12345"
+
+	ip := ClientIP(r)
+	if ip != "192.168.1.100" {
+		t.Fatalf("expected 192.168.1.100, got %s", ip)
+	}
+}
+
+func TestClientIP_IPv6(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "[::1]:12345"
+
+	ip := ClientIP(r)
+	if ip != "::1" {
+		t.Fatalf("expected ::1, got %s", ip)
+	}
+}
+
+func TestNormalizeIP(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"192.168.1.1", "192.168.1.1"},
+		{"::1", "::1"},
+		{"  10.0.0.1 ", "10.0.0.1"},
+		{"::ffff:192.168.1.1", "192.168.1.1"}, // IPv4-mapped IPv6
+	}
+
+	for _, tc := range cases {
+		got := normalizeIP(tc.input)
+		if got != tc.expected {
+			t.Errorf("normalizeIP(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestIsTrusted(t *testing.T) {
+	trusted := []string{"10.0.0.0/8", "172.16.0.1"}
+
+	cases := []struct {
+		ip       string
+		expected bool
+	}{
+		{"10.0.0.1", true},
+		{"10.255.255.255", true},
+		{"172.16.0.1", true},
+		{"172.16.0.2", false},
+		{"192.168.1.1", false},
+	}
+
+	for _, tc := range cases {
+		got := isTrusted(tc.ip, trusted)
+		if got != tc.expected {
+			t.Errorf("isTrusted(%q) = %v, want %v", tc.ip, got, tc.expected)
+		}
+	}
+}
+
+func TestCoarsenIPv6(t *testing.T) {
+	// IPv4 unchanged
+	if got := CoarsenIPv6("192.168.1.1"); got != "192.168.1.1" {
+		t.Fatalf("IPv4 should be unchanged, got %s", got)
+	}
+
+	// IPv6 coarsened to /64
+	result := CoarsenIPv6("2001:db8:85a3::8a2e:370:7334")
+	if result != "2001:db8:85a3::/64" {
+		t.Fatalf("expected 2001:db8:85a3::/64, got %s", result)
+	}
+}

--- a/internal/ratelimit/doc.go
+++ b/internal/ratelimit/doc.go
@@ -1,0 +1,76 @@
+// Package ratelimit provides a middleware-based rate limiter for the Gohst
+// framework using a token-bucket algorithm.
+//
+// # Overview
+//
+// The rate limiter protects routes from abuse by tracking requests per key
+// (IP, user ID, bearer token, or composite keys) and enforcing configurable
+// limits with optional burst capacity.
+//
+// Two store backends are provided:
+//   - In-memory (single instance / development)
+//   - Redis with atomic Lua scripts (production / multi-instance)
+//
+// # Quick Start
+//
+// Create a store and a limiter, then add it to your middleware chain:
+//
+//	store := ratelimit.NewStore() // reads RATE_LIMIT_STORE env
+//
+//	limiter := ratelimit.NewPublicBrowseLimiter(store)
+//
+//	handler := middleware.Chain(
+//	    mux,
+//	    limiter.Middleware,
+//	    session.SM.SessionMiddleware,
+//	    middleware.CSRF,
+//	    middleware.Logger,
+//	)
+//
+// # Preset Policies
+//
+// Four ready-made policies cover common use cases:
+//
+//   - [PublicBrowsePolicy]: 300/min, burst 60 — anonymous page browsing
+//   - [APIDefaultPolicy]: 120/min, burst 30 — authenticated API traffic
+//   - [AuthSensitivePolicy]: 10/min, no burst — login / password reset
+//   - [ExportsPolicy]: 10/min, no burst, concurrency 1 — heavy operations
+//
+// # Custom Policies
+//
+// Build your own policy for any route group:
+//
+//	limiter := ratelimit.NewLimiter(
+//	    store,
+//	    ratelimit.Policy{
+//	        Limit:   50,
+//	        Window:  30 * time.Second,
+//	        Burst:   10,
+//	        Scope:   "api_search",
+//	        Enabled: true,
+//	        Cost:    5, // expensive endpoints consume more tokens
+//	    },
+//	    ratelimit.KeyByTokenElseUserElseIP(),
+//	)
+//
+// # Key Strategies
+//
+// Key functions determine "who" is being rate-limited:
+//
+//   - [KeyByIP]: by client IP address
+//   - [KeyByUserElseIP]: by authenticated user ID, falling back to IP
+//   - [KeyByTokenElseUserElseIP]: by bearer token, then user, then IP
+//   - [KeyByIPAndIdentifier]: by IP + form field (e.g. email) — for brute-force protection
+//   - [KeyByIPAndRoute]: by IP + request path — for per-endpoint limits
+//   - [KeyByIPAndUA]: by IP + user-agent hash
+//
+// # Configuration
+//
+// All settings are configurable via environment variables (see [config.RateLimitConfig]):
+//
+//	RATE_LIMIT_ENABLED, RATE_LIMIT_STORE, RATE_LIMIT_REDIS_PREFIX,
+//	RATE_LIMIT_RESPONSE_FORMAT, RATE_LIMIT_LOG_TABLE, RATE_LIMIT_TRUSTED_PROXIES,
+//	RATE_LIMIT_DEFAULT_LIMIT, RATE_LIMIT_DEFAULT_WINDOW, RATE_LIMIT_DEFAULT_BURST
+//
+// See the README.md in this directory for the full reference.
+package ratelimit

--- a/internal/ratelimit/keys.go
+++ b/internal/ratelimit/keys.go
@@ -1,0 +1,149 @@
+package ratelimit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"gohst/internal/auth"
+	"gohst/internal/session"
+)
+
+// ──────────────────────────────────────────────
+// Key types
+// ──────────────────────────────────────────────
+
+const (
+	KeyTypeToken   = "token"
+	KeyTypeUser    = "user"
+	KeyTypeSession = "session"
+	KeyTypeIP      = "ip"
+	KeyTypeIPUA    = "ipua"
+	KeyTypeIPRoute = "iproute"
+	KeyTypeIPIdent = "ipident"
+)
+
+// KeyFunc computes a (key, keyType) pair from a request.
+type KeyFunc func(r *http.Request) (key string, keyType string)
+
+// ──────────────────────────────────────────────
+// Pre-built key functions
+// ──────────────────────────────────────────────
+
+// KeyByIP keys solely by the client IP address.
+func KeyByIP() KeyFunc {
+	return func(r *http.Request) (string, string) {
+		ip := ClientIP(r)
+		return "ip:" + ip, KeyTypeIP
+	}
+}
+
+// KeyByUserElseIP keys by authenticated user ID, falling back to IP.
+func KeyByUserElseIP() KeyFunc {
+	return func(r *http.Request) (string, string) {
+		sess := session.FromContext(r.Context())
+		if sess != nil && auth.IsAuthenticated(sess) {
+			if uid, ok := sess.Get("user_id"); ok && uid != nil {
+				return fmt.Sprintf("user:%v", uid), KeyTypeUser
+			}
+		}
+		ip := ClientIP(r)
+		return "ip:" + ip, KeyTypeIP
+	}
+}
+
+// KeyByTokenElseUserElseIP keys by bearer token hash, then user ID, then IP.
+func KeyByTokenElseUserElseIP() KeyFunc {
+	return func(r *http.Request) (string, string) {
+		// Check for bearer token
+		if token := extractBearerToken(r); token != "" {
+			return "token:" + hashValue(token), KeyTypeToken
+		}
+		// Check for authenticated user
+		sess := session.FromContext(r.Context())
+		if sess != nil && auth.IsAuthenticated(sess) {
+			if uid, ok := sess.Get("user_id"); ok && uid != nil {
+				return fmt.Sprintf("user:%v", uid), KeyTypeUser
+			}
+		}
+		// Fallback to IP
+		ip := ClientIP(r)
+		return "ip:" + ip, KeyTypeIP
+	}
+}
+
+// KeyByIPAndIdentifier creates a composite key from IP + a form/query value,
+// ideal for login/reset endpoints where you want to limit attempts on a
+// specific account from a specific IP.
+//
+// The identifier (e.g. email) is normalised and hashed so it is safe to log
+// and store.
+func KeyByIPAndIdentifier(field string) KeyFunc {
+	return func(r *http.Request) (string, string) {
+		ip := ClientIP(r)
+		identifier := extractIdentifier(r, field)
+		return fmt.Sprintf("ipident:%s:%s", ip, hashValue(identifier)), KeyTypeIPIdent
+	}
+}
+
+// KeyByIPAndRoute creates a composite key from IP + request path,
+// useful for limiting expensive endpoints without penalising the whole site.
+func KeyByIPAndRoute() KeyFunc {
+	return func(r *http.Request) (string, string) {
+		ip := ClientIP(r)
+		route := r.URL.Path
+		return fmt.Sprintf("iproute:%s:%s", ip, route), KeyTypeIPRoute
+	}
+}
+
+// KeyByIPAndUA creates a composite key from IP + user-agent hash.
+func KeyByIPAndUA() KeyFunc {
+	return func(r *http.Request) (string, string) {
+		ip := ClientIP(r)
+		ua := r.Header.Get("User-Agent")
+		return fmt.Sprintf("ipua:%s:%s", ip, hashValue(ua)), KeyTypeIPUA
+	}
+}
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+// extractBearerToken pulls a bearer token from the Authorization header.
+func extractBearerToken(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if len(h) > len(prefix) && strings.EqualFold(h[:len(prefix)], prefix) {
+		return strings.TrimSpace(h[len(prefix):])
+	}
+	return ""
+}
+
+// extractIdentifier reads a value from form data or query params,
+// normalises it (trim + lowercase).
+func extractIdentifier(r *http.Request, field string) string {
+	// Try form body first (must parse form)
+	if r.Method == http.MethodPost || r.Method == http.MethodPut {
+		_ = r.ParseForm()
+		if v := r.FormValue(field); v != "" {
+			return strings.ToLower(strings.TrimSpace(v))
+		}
+	}
+	// Query param fallback
+	if v := r.URL.Query().Get(field); v != "" {
+		return strings.ToLower(strings.TrimSpace(v))
+	}
+	return ""
+}
+
+// hashValue returns the first 16 chars of the SHA-256 hex digest.
+// This is safe to log and store; the original value cannot be recovered.
+func hashValue(v string) string {
+	h := sha256.Sum256([]byte(v))
+	return hex.EncodeToString(h[:])[:16]
+}

--- a/internal/ratelimit/keys_test.go
+++ b/internal/ratelimit/keys_test.go
@@ -1,0 +1,86 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestKeyByIP(t *testing.T) {
+	fn := KeyByIP()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "1.2.3.4:9999"
+
+	key, keyType := fn(r)
+	if keyType != KeyTypeIP {
+		t.Fatalf("expected keyType %q, got %q", KeyTypeIP, keyType)
+	}
+	if key != "ip:1.2.3.4" {
+		t.Fatalf("expected key ip:1.2.3.4, got %s", key)
+	}
+}
+
+func TestKeyByIPAndRoute(t *testing.T) {
+	fn := KeyByIPAndRoute()
+	r := httptest.NewRequest(http.MethodGet, "/api/export", nil)
+	r.RemoteAddr = "10.0.0.1:1234"
+
+	key, keyType := fn(r)
+	if keyType != KeyTypeIPRoute {
+		t.Fatalf("expected keyType %q, got %q", KeyTypeIPRoute, keyType)
+	}
+	expected := "iproute:10.0.0.1:/api/export"
+	if key != expected {
+		t.Fatalf("expected key %q, got %q", expected, key)
+	}
+}
+
+func TestKeyByIPAndUA(t *testing.T) {
+	fn := KeyByIPAndUA()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1234"
+	r.Header.Set("User-Agent", "Mozilla/5.0")
+
+	key, keyType := fn(r)
+	if keyType != KeyTypeIPUA {
+		t.Fatalf("expected keyType %q, got %q", KeyTypeIPUA, keyType)
+	}
+	if key == "" {
+		t.Fatal("key should not be empty")
+	}
+}
+
+func TestExtractBearerToken(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer my-secret-token")
+
+	tok := extractBearerToken(r)
+	if tok != "my-secret-token" {
+		t.Fatalf("expected my-secret-token, got %s", tok)
+	}
+
+	// No header
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	if extractBearerToken(r2) != "" {
+		t.Fatal("should return empty when no header")
+	}
+}
+
+func TestHashValue_Deterministic(t *testing.T) {
+	a := hashValue("test@example.com")
+	b := hashValue("test@example.com")
+	if a != b {
+		t.Fatal("hash should be deterministic")
+	}
+	if len(a) != 16 {
+		t.Fatalf("expected 16 char hash, got %d", len(a))
+	}
+}
+
+func TestHashValue_DifferentInputs(t *testing.T) {
+	a := hashValue("alice@example.com")
+	b := hashValue("bob@example.com")
+	if a == b {
+		t.Fatal("different inputs should produce different hashes")
+	}
+}

--- a/internal/ratelimit/log.go
+++ b/internal/ratelimit/log.go
@@ -1,0 +1,81 @@
+package ratelimit
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+
+	"gohst/internal/db"
+)
+
+// ──────────────────────────────────────────────
+// Rate-limit deny log
+// ──────────────────────────────────────────────
+
+// LogEntry is a single denied-request record.
+type LogEntry struct {
+	Method     string
+	Path       string
+	KeyType    string
+	KeyHash    string
+	Scope      string
+	RetryAfter int
+	ClientIP   string
+}
+
+// LogStore persists denied-request log entries.
+type LogStore interface {
+	Log(entry LogEntry) error
+}
+
+// ──────────────────────────────────────────────
+// Database log store (PostgreSQL)
+// ──────────────────────────────────────────────
+
+// DBLogStore writes denied-request records to the rate_limit_logs table.
+type DBLogStore struct {
+	db *sql.DB
+}
+
+// NewDBLogStore creates a database-backed log store using the primary DB.
+func NewDBLogStore() *DBLogStore {
+	primary := db.GetPrimaryDB()
+	if primary == nil {
+		log.Println("[ratelimit] warning: no primary DB available for log store")
+		return &DBLogStore{}
+	}
+	return &DBLogStore{db: primary.DB}
+}
+
+// Log inserts a denied-request entry.
+func (s *DBLogStore) Log(entry LogEntry) error {
+	if s.db == nil {
+		return fmt.Errorf("database not available")
+	}
+
+	query := `
+		INSERT INTO rate_limit_logs (method, path, key_type, key_hash, scope, retry_after, client_ip, denied_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+
+	_, err := s.db.Exec(query,
+		entry.Method,
+		entry.Path,
+		entry.KeyType,
+		entry.KeyHash,
+		entry.Scope,
+		entry.RetryAfter,
+		entry.ClientIP,
+		time.Now().UTC(),
+	)
+	return err
+}
+
+// ──────────────────────────────────────────────
+// No-op log store (discard)
+// ──────────────────────────────────────────────
+
+// NopLogStore discards all log entries. Used when DB logging is disabled.
+type NopLogStore struct{}
+
+func (NopLogStore) Log(_ LogEntry) error { return nil }

--- a/internal/ratelimit/middleware.go
+++ b/internal/ratelimit/middleware.go
@@ -1,0 +1,222 @@
+package ratelimit
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"gohst/internal/config"
+)
+
+// ──────────────────────────────────────────────
+// Middleware
+// ──────────────────────────────────────────────
+
+// OnLimitFunc is an optional callback invoked when a request is rate-limited.
+// Return true to indicate the response has been handled; false to use default 429.
+type OnLimitFunc func(w http.ResponseWriter, r *http.Request, result Result) bool
+
+// Limiter holds all the dependencies for a rate-limit middleware instance.
+type Limiter struct {
+	store            Store
+	concurrencyStore ConcurrencyStore
+	policy           Policy
+	keyFunc          KeyFunc
+	onLimit          OnLimitFunc
+	allowlist        []AllowRule
+	logStore         LogStore
+}
+
+// Option configures a Limiter.
+type Option func(*Limiter)
+
+// WithOnLimit sets a custom 429 handler.
+func WithOnLimit(fn OnLimitFunc) Option {
+	return func(l *Limiter) { l.onLimit = fn }
+}
+
+// WithConcurrency attaches a concurrency store.
+func WithConcurrency(cs ConcurrencyStore) Option {
+	return func(l *Limiter) { l.concurrencyStore = cs }
+}
+
+// WithAllowlist adds bypass rules.
+func WithAllowlist(rules ...AllowRule) Option {
+	return func(l *Limiter) { l.allowlist = rules }
+}
+
+// WithLogStore attaches a log store for denied-request logging.
+func WithLogStore(ls LogStore) Option {
+	return func(l *Limiter) { l.logStore = ls }
+}
+
+// NewLimiter creates a new Limiter.
+func NewLimiter(store Store, policy Policy, keyFunc KeyFunc, opts ...Option) *Limiter {
+	l := &Limiter{
+		store:   store,
+		policy:  policy,
+		keyFunc: keyFunc,
+	}
+	for _, o := range opts {
+		o(l)
+	}
+	return l
+}
+
+// Middleware returns an http middleware function compatible with the existing
+// middleware.Chain helper.
+func (l *Limiter) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Global kill-switch
+		if !config.RateLimit.Enabled || !l.policy.Enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Allowlist bypass
+		for _, rule := range l.allowlist {
+			if rule.Matches(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		key, keyType := l.keyFunc(r)
+		cost := l.policy.Cost
+		if cost < 1 {
+			cost = 1
+		}
+
+		// ── Concurrency limit check ────────────────
+		if l.policy.ConcurrencyLimit > 0 && l.concurrencyStore != nil {
+			ok, err := l.concurrencyStore.Acquire(key, l.policy.ConcurrencyLimit)
+			if err != nil {
+				log.Printf("[ratelimit] concurrency store error key=%s: %v", truncateKey(key), err)
+			}
+			if !ok {
+				l.denyResponse(w, r, Result{
+					Allowed:    false,
+					Limit:      l.policy.ConcurrencyLimit,
+					Remaining:  0,
+					RetryAfter: 1,
+					ResetAt:    0,
+				}, key, keyType, "concurrency")
+				return
+			}
+			defer func() {
+				if err := l.concurrencyStore.Release(key); err != nil {
+					log.Printf("[ratelimit] concurrency release error key=%s: %v", truncateKey(key), err)
+				}
+			}()
+		}
+
+		// ── Rate limit check ───────────────────────
+		result := l.store.Allow(key, l.policy, cost)
+
+		// Always set rate-limit headers, even on success.
+		setRateLimitHeaders(w, result)
+
+		if !result.Allowed {
+			l.denyResponse(w, r, result, key, keyType, "rate")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// denyResponse writes a 429 response with proper headers and logging.
+func (l *Limiter) denyResponse(w http.ResponseWriter, r *http.Request, result Result, key, keyType, reason string) {
+	// Log at warn level (never log raw secrets)
+	log.Printf("[ratelimit] DENIED %s %s | type=%s scope=%s key=%s retryAfter=%ds reason=%s",
+		r.Method, r.URL.Path, keyType, l.policy.Scope, truncateKey(key), result.RetryAfter, reason)
+
+	// Log to database if configured
+	if l.logStore != nil {
+		entry := LogEntry{
+			Method:     r.Method,
+			Path:       r.URL.Path,
+			KeyType:    keyType,
+			KeyHash:    truncateKey(key),
+			Scope:      l.policy.Scope,
+			RetryAfter: result.RetryAfter,
+			ClientIP:   ClientIP(r),
+		}
+		if err := l.logStore.Log(entry); err != nil {
+			log.Printf("[ratelimit] failed to write log entry: %v", err)
+		}
+	}
+
+	// Custom handler?
+	if l.onLimit != nil && l.onLimit(w, r, result) {
+		return
+	}
+
+	// Default 429
+	setRateLimitHeaders(w, result)
+
+	format := config.RateLimit.DefaultResponseFormat
+	// Heuristic: if Accept header prefers JSON, use JSON regardless of config.
+	accept := r.Header.Get("Accept")
+	if containsJSON(accept) {
+		format = "json"
+	}
+
+	w.Header().Set("Retry-After", strconv.Itoa(result.RetryAfter))
+
+	switch format {
+	case "json":
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusTooManyRequests)
+		resp := map[string]interface{}{
+			"error":       "Too Many Requests",
+			"retry_after": result.RetryAfter,
+			"message":     "Rate limit exceeded. Please slow down and try again later.",
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	default:
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><title>429 Too Many Requests</title></head>
+<body>
+<h1>Too Many Requests</h1>
+<p>You have exceeded the rate limit. Please try again in %d seconds.</p>
+</body></html>`, result.RetryAfter)
+	}
+}
+
+// setRateLimitHeaders writes the standard rate-limit response headers.
+func setRateLimitHeaders(w http.ResponseWriter, r Result) {
+	w.Header().Set("X-RateLimit-Limit", strconv.Itoa(r.Limit))
+	w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(r.Remaining))
+	w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(r.ResetAt, 10))
+}
+
+// truncateKey returns a safe-to-log version of the key.
+func truncateKey(key string) string {
+	if len(key) > 40 {
+		return key[:40] + "..."
+	}
+	return key
+}
+
+// containsJSON checks if an Accept header indicates JSON preference.
+func containsJSON(accept string) bool {
+	return len(accept) > 0 && (contains(accept, "application/json") || contains(accept, "text/json"))
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ratelimit/middleware_test.go
+++ b/internal/ratelimit/middleware_test.go
@@ -1,0 +1,224 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gohst/internal/config"
+)
+
+// initTestConfig sets up a minimal config so the middleware can function.
+func initTestConfig() {
+	config.RateLimit = &config.RateLimitConfig{
+		Enabled:               true,
+		Store:                 "memory",
+		RedisPrefix:           "test:rl:",
+		DefaultResponseFormat: "json",
+		TrustedProxies:        nil,
+		DefaultLimit:          300,
+		DefaultWindow:         60,
+		DefaultBurst:          60,
+	}
+}
+
+func TestMiddleware_AllowsWithinLimit(t *testing.T) {
+	initTestConfig()
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 5, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+	limiter := NewLimiter(store, p, KeyByIP())
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, rr.Code)
+		}
+
+		// Should have rate limit headers
+		if rr.Header().Get("X-RateLimit-Limit") == "" {
+			t.Fatal("missing X-RateLimit-Limit header")
+		}
+		if rr.Header().Get("X-RateLimit-Remaining") == "" {
+			t.Fatal("missing X-RateLimit-Remaining header")
+		}
+	}
+}
+
+func TestMiddleware_DeniesAfterLimit(t *testing.T) {
+	initTestConfig()
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 3, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+	limiter := NewLimiter(store, p, KeyByIP())
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 3; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		handler.ServeHTTP(rr, req)
+	}
+
+	// 4th request should be denied
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "1.2.3.4:1234"
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Fatal("missing Retry-After header")
+	}
+}
+
+func TestMiddleware_DisabledGlobally(t *testing.T) {
+	initTestConfig()
+	config.RateLimit.Enabled = false
+
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 1, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+	limiter := NewLimiter(store, p, KeyByIP())
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Should always allow when disabled
+	for i := 0; i < 10; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200 (disabled), got %d", i+1, rr.Code)
+		}
+	}
+}
+
+func TestMiddleware_DisabledPerPolicy(t *testing.T) {
+	initTestConfig()
+
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 1, Window: time.Minute, Burst: 0, Enabled: false, Cost: 1, Scope: "test"}
+	limiter := NewLimiter(store, p, KeyByIP())
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 10; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200 (policy disabled), got %d", i+1, rr.Code)
+		}
+	}
+}
+
+func TestMiddleware_AllowlistBypass(t *testing.T) {
+	initTestConfig()
+
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 1, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+	limiter := NewLimiter(store, p, KeyByIP(),
+		WithAllowlist(BypassPaths{Prefixes: []string{"/healthz"}}),
+	)
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Bypassed path — always allowed
+	for i := 0; i < 10; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("bypassed path should always return 200, got %d", rr.Code)
+		}
+	}
+}
+
+func TestMiddleware_JSONResponse(t *testing.T) {
+	initTestConfig()
+	config.RateLimit.DefaultResponseFormat = "json"
+
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 1, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+	limiter := NewLimiter(store, p, KeyByIP())
+
+	handler := limiter.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Exhaust
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "5.6.7.8:1234"
+	handler.ServeHTTP(rr, req)
+
+	// Denied
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "5.6.7.8:1234"
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rr.Code)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json; charset=utf-8" {
+		t.Fatalf("expected JSON content type, got %s", ct)
+	}
+}
+
+func TestMemoryConcurrencyStore(t *testing.T) {
+	cs := NewMemoryConcurrencyStore()
+
+	ok, _ := cs.Acquire("k1", 2)
+	if !ok {
+		t.Fatal("1st acquire should succeed")
+	}
+	ok, _ = cs.Acquire("k1", 2)
+	if !ok {
+		t.Fatal("2nd acquire should succeed")
+	}
+	ok, _ = cs.Acquire("k1", 2)
+	if ok {
+		t.Fatal("3rd acquire should fail (limit=2)")
+	}
+
+	cs.Release("k1")
+	ok, _ = cs.Acquire("k1", 2)
+	if !ok {
+		t.Fatal("acquire after release should succeed")
+	}
+}

--- a/internal/ratelimit/policy.go
+++ b/internal/ratelimit/policy.go
@@ -1,0 +1,93 @@
+package ratelimit
+
+import (
+	"time"
+)
+
+// Policy defines a rate-limit policy that can be attached to a route or group.
+type Policy struct {
+	// Limit is the maximum number of allowed requests in the window.
+	Limit int
+
+	// Window is the time period for the limit.
+	Window time.Duration
+
+	// Burst is extra capacity for short spikes (token bucket style).
+	// Set to 0 for strict limiting (fixed-window behaviour).
+	Burst int
+
+	// Scope is an optional human-readable name used for logging/reporting.
+	Scope string
+
+	// Enabled allows per-policy overrides. When false the middleware is a no-op.
+	Enabled bool
+
+	// Cost is the token cost of a single request (default 1).
+	// Use higher values for expensive endpoints.
+	Cost int
+
+	// ConcurrencyLimit caps the number of in-flight requests per key.
+	// 0 means unlimited.
+	ConcurrencyLimit int
+}
+
+// DefaultPolicy returns a sensible default (300/min, burst 60).
+func DefaultPolicy() Policy {
+	return Policy{
+		Limit:   300,
+		Window:  60 * time.Second,
+		Burst:   60,
+		Scope:   "default",
+		Enabled: true,
+		Cost:    1,
+	}
+}
+
+// PublicBrowsePolicy is a generous limit for anonymous page browsing.
+func PublicBrowsePolicy() Policy {
+	return Policy{
+		Limit:   300,
+		Window:  60 * time.Second,
+		Burst:   60,
+		Scope:   "public_browse",
+		Enabled: true,
+		Cost:    1,
+	}
+}
+
+// APIDefaultPolicy is the standard limit for authenticated API traffic.
+func APIDefaultPolicy() Policy {
+	return Policy{
+		Limit:   120,
+		Window:  60 * time.Second,
+		Burst:   30,
+		Scope:   "api_default",
+		Enabled: true,
+		Cost:    1,
+	}
+}
+
+// AuthSensitivePolicy is a tight limit for login / password-reset.
+func AuthSensitivePolicy() Policy {
+	return Policy{
+		Limit:   10,
+		Window:  60 * time.Second,
+		Burst:   0,
+		Scope:   "auth_sensitive",
+		Enabled: true,
+		Cost:    1,
+	}
+}
+
+// ExportsPolicy is very tight plus concurrency cap.
+func ExportsPolicy() Policy {
+	return Policy{
+		Limit:            10,
+		Window:           60 * time.Second,
+		Burst:            0,
+		Scope:            "exports",
+		Enabled:          true,
+		Cost:             1,
+		ConcurrencyLimit: 1,
+	}
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,0 +1,66 @@
+package ratelimit
+
+import (
+	"log"
+	"time"
+
+	"gohst/internal/config"
+)
+
+// ──────────────────────────────────────────────
+// Factory helpers
+// ──────────────────────────────────────────────
+
+// NewStore creates a Store based on the current config ("memory" or "redis").
+func NewStore() Store {
+	switch config.RateLimit.Store {
+	case "redis":
+		log.Println("[ratelimit] using Redis store")
+		return NewRedisStore()
+	default:
+		log.Println("[ratelimit] using in-memory store")
+		return NewMemoryStore(2 * time.Minute)
+	}
+}
+
+// NewLogStore creates a LogStore based on config.
+func NewLogStoreFromConfig() LogStore {
+	if config.RateLimit.LogTableEnabled {
+		log.Println("[ratelimit] database logging enabled")
+		return NewDBLogStore()
+	}
+	return NopLogStore{}
+}
+
+// ──────────────────────────────────────────────
+// Convenience constructors – create a ready-to-use Limiter for common cases.
+// ──────────────────────────────────────────────
+
+// NewPublicBrowseLimiter creates a limiter suitable for anonymous page browsing.
+//
+// Usage in routes:
+//
+//	limiter := ratelimit.NewPublicBrowseLimiter(store)
+//	handler = middleware.Chain(mux, limiter.Middleware, ...)
+func NewPublicBrowseLimiter(store Store, opts ...Option) *Limiter {
+	return NewLimiter(store, PublicBrowsePolicy(), KeyByUserElseIP(), opts...)
+}
+
+// NewAPIDefaultLimiter creates a limiter for general API endpoints.
+func NewAPIDefaultLimiter(store Store, opts ...Option) *Limiter {
+	return NewLimiter(store, APIDefaultPolicy(), KeyByTokenElseUserElseIP(), opts...)
+}
+
+// NewAuthSensitiveLimiter creates a tight limiter for login/reset endpoints.
+// `identifierField` is the form field name (e.g. "email") used to build
+// composite keys so that brute-force attacks on a specific account are
+// limited even if the attacker rotates IPs slightly.
+func NewAuthSensitiveLimiter(store Store, identifierField string, opts ...Option) *Limiter {
+	return NewLimiter(store, AuthSensitivePolicy(), KeyByIPAndIdentifier(identifierField), opts...)
+}
+
+// NewExportsLimiter creates a very tight limiter with concurrency cap.
+func NewExportsLimiter(store Store, concStore ConcurrencyStore, opts ...Option) *Limiter {
+	opts = append(opts, WithConcurrency(concStore))
+	return NewLimiter(store, ExportsPolicy(), KeyByTokenElseUserElseIP(), opts...)
+}

--- a/internal/ratelimit/store_memory.go
+++ b/internal/ratelimit/store_memory.go
@@ -1,0 +1,103 @@
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// ──────────────────────────────────────────────
+// In-memory Store (dev / single-instance)
+// ──────────────────────────────────────────────
+
+type memEntry struct {
+	bucket    *Bucket
+	expiresAt time.Time // for cleanup
+}
+
+// MemoryStore is a thread-safe, in-process rate-limit store backed by a
+// token-bucket per key. Expired entries are swept periodically.
+type MemoryStore struct {
+	mu      sync.Mutex
+	entries map[string]*memEntry
+	stop    chan struct{}
+}
+
+// NewMemoryStore creates a MemoryStore with a background cleanup goroutine
+// that runs every `cleanupInterval`.
+func NewMemoryStore(cleanupInterval time.Duration) *MemoryStore {
+	s := &MemoryStore{
+		entries: make(map[string]*memEntry),
+		stop:    make(chan struct{}),
+	}
+	go s.cleanup(cleanupInterval)
+	return s
+}
+
+// Allow checks whether the key is within its rate limit.
+func (s *MemoryStore) Allow(key string, policy Policy, cost int) Result {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	e, ok := s.entries[key]
+	if !ok {
+		b := NewBucket(policy)
+		e = &memEntry{
+			bucket:    b,
+			expiresAt: now.Add(policy.Window * 2), // keep alive for 2 windows
+		}
+		s.entries[key] = e
+	}
+	// update expiry on every touch
+	e.expiresAt = now.Add(policy.Window * 2)
+
+	remaining, allowed := e.bucket.Allow(cost, now)
+
+	res := Result{
+		Allowed:   allowed,
+		Limit:     policy.Limit + policy.Burst,
+		Remaining: remaining,
+		ResetAt:   e.bucket.ResetUnix(),
+	}
+	if !allowed {
+		res.RetryAfter = int(e.bucket.RetryAfter(cost))
+		if res.RetryAfter < 1 {
+			res.RetryAfter = 1
+		}
+	}
+	return res
+}
+
+// Reset removes a key from the store (e.g. after successful login).
+func (s *MemoryStore) Reset(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, key)
+	return nil
+}
+
+// Close stops the background cleanup goroutine.
+func (s *MemoryStore) Close() error {
+	close(s.stop)
+	return nil
+}
+
+// cleanup periodically removes expired entries.
+func (s *MemoryStore) cleanup(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case now := <-ticker.C:
+			s.mu.Lock()
+			for k, e := range s.entries {
+				if now.After(e.expiresAt) {
+					delete(s.entries, k)
+				}
+			}
+			s.mu.Unlock()
+		}
+	}
+}

--- a/internal/ratelimit/store_memory_test.go
+++ b/internal/ratelimit/store_memory_test.go
@@ -1,0 +1,92 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemoryStore_AllowUpToLimit(t *testing.T) {
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 5, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+
+	for i := 0; i < 5; i++ {
+		res := store.Allow("test-key", p, 1)
+		if !res.Allowed {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+
+	res := store.Allow("test-key", p, 1)
+	if res.Allowed {
+		t.Fatal("6th request should be denied")
+	}
+	if res.RetryAfter < 1 {
+		t.Fatal("retryAfter should be at least 1")
+	}
+}
+
+func TestMemoryStore_DifferentKeysIndependent(t *testing.T) {
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 1, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+
+	res := store.Allow("key-a", p, 1)
+	if !res.Allowed {
+		t.Fatal("key-a should be allowed")
+	}
+	res = store.Allow("key-a", p, 1)
+	if res.Allowed {
+		t.Fatal("key-a should be denied after limit")
+	}
+
+	// key-b is independent
+	res = store.Allow("key-b", p, 1)
+	if !res.Allowed {
+		t.Fatal("key-b should be allowed (independent bucket)")
+	}
+}
+
+func TestMemoryStore_Reset(t *testing.T) {
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 1, Window: time.Minute, Burst: 0, Enabled: true, Cost: 1, Scope: "test"}
+
+	store.Allow("reset-key", p, 1)
+	res := store.Allow("reset-key", p, 1)
+	if res.Allowed {
+		t.Fatal("should be denied")
+	}
+
+	// Reset the key
+	store.Reset("reset-key")
+
+	res = store.Allow("reset-key", p, 1)
+	if !res.Allowed {
+		t.Fatal("should be allowed after reset")
+	}
+}
+
+func TestMemoryStore_Headers(t *testing.T) {
+	store := NewMemoryStore(time.Minute)
+	defer store.Close()
+
+	p := Policy{Limit: 10, Window: time.Minute, Burst: 5, Enabled: true, Cost: 1, Scope: "test"}
+
+	res := store.Allow("header-key", p, 1)
+	if !res.Allowed {
+		t.Fatal("should be allowed")
+	}
+	if res.Limit != 15 { // 10 + 5 burst
+		t.Fatalf("expected limit 15, got %d", res.Limit)
+	}
+	if res.Remaining != 14 {
+		t.Fatalf("expected remaining 14, got %d", res.Remaining)
+	}
+	if res.ResetAt <= 0 {
+		t.Fatal("resetAt should be a positive unix timestamp")
+	}
+}

--- a/internal/ratelimit/store_redis.go
+++ b/internal/ratelimit/store_redis.go
@@ -1,0 +1,225 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"gohst/internal/config"
+)
+
+// ──────────────────────────────────────────────
+// Redis Store (production / multi-instance)
+// ──────────────────────────────────────────────
+
+// RedisStore implements Store using a Redis-backed token bucket.
+// Each key is stored as a Redis hash with fields: tokens, max, rate, last.
+// An atomic Lua script performs the refill-then-consume operation so that
+// concurrent requests can never over-admit.
+type RedisStore struct {
+	client *redis.Client
+	prefix string
+}
+
+// NewRedisStore creates a RedisStore. It reads connection details from the
+// rate-limit config (falling back to session Redis config).
+func NewRedisStore() *RedisStore {
+	cfg := config.RateLimit.Redis
+	host := cfg.Host
+	port := cfg.Port
+	password := cfg.Password
+	db := cfg.DB
+	prefix := config.RateLimit.RedisPrefix
+
+	client := redis.NewClient(&redis.Options{
+		Addr:     host + ":" + strconv.Itoa(port),
+		Password: password,
+		DB:       db,
+	})
+
+	return &RedisStore{
+		client: client,
+		prefix: prefix,
+	}
+}
+
+// luaTokenBucket is an atomic Lua script that:
+//  1. refills tokens based on elapsed time
+//  2. tries to consume `cost` tokens
+//  3. returns [allowed(0/1), remaining, retryAfterMs, resetAtUnix]
+//
+// KEYS[1] = bucket key
+// ARGV[1] = max_tokens  (limit + burst)
+// ARGV[2] = refill_rate (tokens per second, as float string)
+// ARGV[3] = cost
+// ARGV[4] = now_ms      (current unix time in milliseconds)
+// ARGV[5] = ttl_seconds  (key expiry)
+var luaTokenBucket = redis.NewScript(`
+local key       = KEYS[1]
+local max       = tonumber(ARGV[1])
+local rate      = tonumber(ARGV[2])
+local cost      = tonumber(ARGV[3])
+local now_ms    = tonumber(ARGV[4])
+local ttl       = tonumber(ARGV[5])
+
+local data = redis.call("HMGET", key, "tokens", "last_ms")
+local tokens  = tonumber(data[1])
+local last_ms = tonumber(data[2])
+
+if tokens == nil then
+    -- first request: start with full bucket
+    tokens  = max
+    last_ms = now_ms
+end
+
+-- refill
+local elapsed_s = (now_ms - last_ms) / 1000.0
+if elapsed_s > 0 then
+    tokens = math.min(max, tokens + elapsed_s * rate)
+    last_ms = now_ms
+end
+
+local allowed   = 0
+local remaining = math.floor(tokens)
+local retry_ms  = 0
+
+if tokens >= cost then
+    tokens    = tokens - cost
+    remaining = math.floor(tokens)
+    allowed   = 1
+else
+    local deficit = cost - tokens
+    retry_ms = math.ceil((deficit / rate) * 1000)
+end
+
+-- persist
+redis.call("HMSET", key, "tokens", tostring(tokens), "last_ms", tostring(last_ms))
+redis.call("EXPIRE", key, ttl)
+
+-- compute reset_at: time until full bucket
+local deficit_full = max - tokens
+local reset_s = 0
+if deficit_full > 0 and rate > 0 then
+    reset_s = deficit_full / rate
+end
+local reset_at = math.floor(now_ms / 1000) + math.ceil(reset_s)
+
+return {allowed, remaining, retry_ms, reset_at}
+`)
+
+// Allow checks the rate limit for a key.
+func (s *RedisStore) Allow(key string, policy Policy, cost int) Result {
+	ctx := context.Background()
+	fullKey := s.prefix + key
+
+	maxTokens := float64(policy.Limit + policy.Burst)
+	refillRate := float64(policy.Limit) / policy.Window.Seconds()
+	nowMs := time.Now().UnixMilli()
+	ttl := int(policy.Window.Seconds()) * 2 // keep key for 2 windows
+
+	vals, err := luaTokenBucket.Run(ctx, s.client, []string{fullKey},
+		fmt.Sprintf("%.4f", maxTokens),
+		fmt.Sprintf("%.4f", refillRate),
+		cost,
+		nowMs,
+		ttl,
+	).Int64Slice()
+
+	if err != nil {
+		// On Redis error, fail open (allow the request).
+		return Result{
+			Allowed:   true,
+			Limit:     policy.Limit + policy.Burst,
+			Remaining: policy.Limit + policy.Burst,
+		}
+	}
+
+	allowed := vals[0] == 1
+	remaining := int(vals[1])
+	retryMs := int(vals[2])
+	resetAt := vals[3]
+
+	retryAfter := retryMs / 1000
+	if !allowed && retryAfter < 1 {
+		retryAfter = 1
+	}
+
+	return Result{
+		Allowed:    allowed,
+		Limit:      policy.Limit + policy.Burst,
+		Remaining:  remaining,
+		RetryAfter: retryAfter,
+		ResetAt:    resetAt,
+	}
+}
+
+// Reset removes a key from the store.
+func (s *RedisStore) Reset(key string) error {
+	return s.client.Del(context.Background(), s.prefix+key).Err()
+}
+
+// Close shuts down the Redis client.
+func (s *RedisStore) Close() error {
+	return s.client.Close()
+}
+
+// ──────────────────────────────────────────────
+// Redis concurrency store
+// ──────────────────────────────────────────────
+
+// RedisConcurrencyStore manages per-key concurrency using Redis INCR/DECR
+// with a safety TTL so keys auto-expire if a release is missed.
+type RedisConcurrencyStore struct {
+	client *redis.Client
+	prefix string
+	ttl    time.Duration // safety TTL for auto-release
+}
+
+// NewRedisConcurrencyStore creates a concurrency store backed by Redis.
+func NewRedisConcurrencyStore(client *redis.Client, prefix string, ttl time.Duration) *RedisConcurrencyStore {
+	return &RedisConcurrencyStore{
+		client: client,
+		prefix: prefix + "conc:",
+		ttl:    ttl,
+	}
+}
+
+// Acquire tries to increment the in-flight counter atomically.
+var luaConcAcquire = redis.NewScript(`
+local key   = KEYS[1]
+local limit = tonumber(ARGV[1])
+local ttl   = tonumber(ARGV[2])
+local cur   = tonumber(redis.call("GET", key) or "0")
+if cur >= limit then
+    return 0
+end
+redis.call("INCR", key)
+redis.call("EXPIRE", key, ttl)
+return 1
+`)
+
+func (r *RedisConcurrencyStore) Acquire(key string, limit int) (bool, error) {
+	ctx := context.Background()
+	res, err := luaConcAcquire.Run(ctx, r.client, []string{r.prefix + key}, limit, int(r.ttl.Seconds())).Int64()
+	if err != nil {
+		return true, nil // fail open
+	}
+	return res == 1, nil
+}
+
+// Release decrements the in-flight counter.
+func (r *RedisConcurrencyStore) Release(key string) error {
+	ctx := context.Background()
+	fullKey := r.prefix + key
+	res, err := r.client.Decr(ctx, fullKey).Result()
+	if err != nil {
+		return err
+	}
+	if res <= 0 {
+		r.client.Del(ctx, fullKey)
+	}
+	return nil
+}

--- a/internal/render/csrf.go
+++ b/internal/render/csrf.go
@@ -18,6 +18,9 @@ const CSRFInputTemplate = `<input type="hidden" name="%s" value="%s">`
 
 func GetCSRF(r *http.Request) *CSRF {
 	sess := session.FromContext(r.Context())
+	if sess == nil {
+		return &CSRF{Token: "", Input: template.HTML("")}
+	}
 	rawToken, _ := sess.GetCSRF()
 	tokenName := config.APP_CSRF_KEY
 	token := rawToken.(string)

--- a/internal/render/view.go
+++ b/internal/render/view.go
@@ -160,15 +160,24 @@ func (v *View) Render(w http.ResponseWriter, r *http.Request, viewName string, d
 	useData := utils.StructSafe(data)
     sess := session.FromContext(r.Context())
 	csrf := GetCSRF(r)
-	authData := auth.GetAuthData(sess)
+
+	var authData any
+	var flash map[string]any
+	var oldData map[string]any
+
+	if sess != nil {
+		authData = auth.GetAuthData(sess)
+		flash = sess.GetAllFlash()
+		oldData = sess.GetAllOld()
+	}
 
 	// Define template data for globlal use in templates
 	templateData := TemplateData{
 		CSRF: csrf,
 		Auth: authData,
 		Data: useData,
-		Flash: sess.GetAllFlash(),
-        OldData:   sess.GetAllOld(),
+		Flash: flash,
+        OldData:   oldData,
 		Request: &RequestProps{
 			Path:   r.URL.Path,
 			Method: r.Method,


### PR DESCRIPTION
Introduce rate limiting functionality with configuration options, logging, and middleware support. Implement a custom 404 error page middleware to enhance user experience. Include necessary database schema updates and examples for usage.